### PR TITLE
Fix OpenAI API

### DIFF
--- a/server/routes/connections.ts
+++ b/server/routes/connections.ts
@@ -230,7 +230,7 @@ async function getOpenAI(key?: string) {
 connectionsRouter.post('/test/openai', async (req, res) => {
     const request = req.body.key;
     const data = await getOpenAI(request);
-    res.send({data});
+    res.send(data);
 });
 
 async function getOpenRouter(key?: string) {


### PR DESCRIPTION
Issue:
The Backend was returning a response object in the format {_object: list, data: data}, which was inconsistent with the Frontend's expectation. The Frontend was designed to receive data containing the list of models directly.

Solution:
Implemented a simple fix in the Backend to adjust its response format. Now, the Backend response aligns with the Frontend's expected format, where data directly contains the list of models.