### PR TITLE
fix: "JavaScript heap out of memory" issue in Vite build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev-react": "vite --host",
     "start-server": "cd ./server && npm run start",
     "build-all": "concurrently \"npm run build\" \"cd ./server && npm run build\"",
-    "build-react": "vite build",
+    "build-react": "NODE_OPTIONS='--max-old-space-size=4096' vite build",
     "build-server": "cd ./server && npm run build",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
I couldn't build the app on my very-low-resource VPS. This fixed it.

Traceback for reference:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0xc94240 node::Abort() [node]
 2: 0xb6df9f  [node]
 3: 0xeb4120 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 4: 0xeb4407 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
 5: 0x10c5a75  [node]
 6: 0x10dd8f8 v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
 7: 0x11364cc v8::internal::MinorGCJob::Task::RunInternal() [node]
 8: 0xd0b8b6  [node]
 9: 0xd0e46f node::PerIsolatePlatformData::FlushForegroundTasksInternal() [node]
10: 0x1874233  [node]
11: 0x1888bfb  [node]
12: 0x1874f57 uv_run [node]
13: 0xbafba6 node::SpinEventLoopInternal(node::Environment*) [node]
14: 0xce16b6 node::NodeMainInstance::Run() [node]
15: 0xc4ce0f node::LoadSnapshotDataAndRun(node::SnapshotData const**, node::InitializationResultImpl const*) [node]
16: 0xc50792 node::Start(int, char**) [node]
17: 0x7f5036685d0a __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
18: 0xbac62e _start [node]
Aborted
```