### PR TITLE
Fix alignment of buttons relative to selects

### DIFF
--- a/src/components/settings/ConnectionPanel.tsx
+++ b/src/components/settings/ConnectionPanel.tsx
@@ -200,7 +200,7 @@ const ConnectionPanel = () => {
 
     return (
         <div className="flex flex-col gap-2 text-base-content">
-            <div className="flex flex-row gap-2 w-full items-center justify-center">
+            <div className="flex flex-row gap-2 w-full items-end justify-center">
                 <RequiredSelectField
                     label="Connection Profile"
                     value={connectionID}

--- a/src/components/settings/DiffusionPanel.tsx
+++ b/src/components/settings/DiffusionPanel.tsx
@@ -168,7 +168,7 @@ const DiffusionPanel = () => {
 
     return (
         <div className="text-base-content flex flex-col gap-2">
-            <div className="flex flex-row gap-2 w-full items-center justify-center">
+            <div className="flex flex-row gap-2 w-full items-end justify-center">
                 <RequiredSelectField
                     label="Profile"
                     value={connectionID}

--- a/src/components/settings/GenerationSettings.tsx
+++ b/src/components/settings/GenerationSettings.tsx
@@ -190,7 +190,7 @@ const GenerationSettings = () => {
 
     return (
         <div className="text-base-content flex flex-col gap-2">
-            <div className="flex flex-row gap-2 w-full items-center justify-center">
+            <div className="flex flex-row gap-2 w-full items-end justify-center">
                 <RequiredSelectField
                     label="Settings Preset"
                     value={presetID}


### PR DESCRIPTION
Fixes the UI being literally unusable (as reported by @LumiWasTaken).
Affected areas: Connection Profile, Settings Preset, Diffusion Profile.

Before 👎:

![image](https://github.com/user-attachments/assets/12c4f1fb-28ea-45b7-b506-5b29a3614cc4)

After 👍:

<img width="762" alt="image" src="https://github.com/user-attachments/assets/b65bbea6-696e-443b-b487-23a80ac3d96e">
